### PR TITLE
Prevent shuffle on each kern change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/MM2SpaceCenter.roboFontExt/lib.3.7/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib.3.7/MM2SpaceCenter.py
@@ -28,6 +28,9 @@ class MM2SpaceCenter:
         print ('MM2SpaceCenter deactivated')
 
     def __init__(self, wordlistPath):
+
+        self.previousPair = None  # temp workaround for overactive notifications from metricsMachine
+
         self.font = metricsMachine.CurrentFont()
         self.pair = metricsMachine.GetCurrentPair()
         self.wordlistPath = wordlistPath
@@ -47,12 +50,15 @@ class MM2SpaceCenter:
 
 
     def MMPairChangedObserver(self, sender):
-        #add code here for when myObserver is triggered
-        currentPair = metricsMachine.GetCurrentPair()
-        if currentPair == self.pair:
-            return
         
-        self.pair = currentPair
+        # temp workaround for overactive notifications from metricsMachine
+        pair = sender["pair"]
+        if pair == self.previousPair:
+            return
+        self.previousPair = pair
+
+        #add code here for when myObserver is triggered
+        self.pair = pair
     
         #print ('current MM pair changed', self.pair)        
         self.wordsForMMPair()


### PR DESCRIPTION
The current script shuffles for every kern adjustment, which makes it hard to use. This is due to MM unintentionally firing off a notification with every kern update, rather than only with each pair change.

This PR is an implementation of fix suggested by Tal Lemming at:

https://twitter.com/TypeSupplyTools/status/1239365389483741185?s=20

Also included is a `.gitignore` file so we don't commit the `.DS_Store` file.