### PR TITLE
Add optional mirrored pair at start of spacing string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -363,6 +363,13 @@ class MM2SpaceCenter:
         string = 'HOH'+pairstring+'HOHO'+pairstring+'OO'
         return string
 
+    # make mirrored pair to judge symmetry of kerns
+    def pairMirrored(self, pair):
+        left, self.leftEncoded = self.checkForUnencodedGname(self.font, pair[0])
+        right, self.rightEncoded = self.checkForUnencodedGname(self.font, pair[1])
+        return left + right + left
+
+
     def wordsForMMPair(self, ):
         
         
@@ -391,7 +398,6 @@ class MM2SpaceCenter:
 
         text = ''
         textList = []
-
 
         # try getting pairstring once in order to check if encoded
         pairstring = self.getPairstring(self.pair)
@@ -503,7 +509,7 @@ class MM2SpaceCenter:
             #make text upper again
             textList = list(  text.upper() for text in textList ) 
 
-        
+
 
 
         if not len(textList) == 0:            
@@ -535,25 +541,23 @@ class MM2SpaceCenter:
             self.messageText = '😞 no words found: '+ pairstring
             self.w.myTextBox.set(self.messageText) 
             
-          
-            
             if makeUpper == True:
-                self.setSpaceCenter(self.font, ' '+pairstring +' '+self.ucString(pairstring)+ previousText)
+                self.setSpaceCenter(self.font, ' '+ self.pairMirrored(self.pair) + ' '+ self.ucString(pairstring)+ previousText)
 
             else:
 
-                self.setSpaceCenter(self.font, ' '+pairstring +' ' +self.lcString(pairstring)+ previousText)
+                self.setSpaceCenter(self.font, ' '+ self.pairMirrored(self.pair) + ' ' + self.lcString(pairstring)+ previousText)
 
 
         
         else:
             #set space center if words are found
             #not sure why there's always a /slash in from of the first word, added ' '+ to avoid losing the first word
-            self.setSpaceCenter(self.font, text)
+            self.setSpaceCenter(self.font, self.pairMirrored(self.pair) + ' ' + text)
             
             self.messageText = '😎 words found: '+ pairstring
             self.w.myTextBox.set(self.messageText)
-            
+
 
 
 

--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -53,7 +53,7 @@ class MM2SpaceCenter:
         self.maxLength = 15
         
         self.activateModule()
-        self.w = Window((250, 100), "MM2SpaceCenter")
+        self.w = Window((250, 130), "MM2SpaceCenter")
         
         self.w.myTextBox = TextBox((leftMargin, yPos, -10, 17), self.messageText, sizeStyle="regular") 
 
@@ -109,8 +109,16 @@ class MM2SpaceCenter:
         checkBoxSize = 18
         self.w.listOutput = CheckBox((leftMargin, yPos, checkBoxSize, checkBoxSize), "", sizeStyle="small", callback=self.sortedCallback)
         self.w.listLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Output as list sorted by width", sizeStyle="small")
+
+        yPos += lineHeight * 1.2
+        
+        checkBoxSize = 18
+        self.w.mirroredPair = CheckBox((leftMargin, yPos, checkBoxSize, checkBoxSize), "", sizeStyle="small", callback=self.sortedCallback)
+        self.w.mirroredPairLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Start with mirrored pair (LRL)", sizeStyle="small")
         
         self.sorted = self.w.listOutput.get()
+
+        self.w.mirroredPair.set(True)
 
 
         
@@ -365,9 +373,12 @@ class MM2SpaceCenter:
 
     # make mirrored pair to judge symmetry of kerns
     def pairMirrored(self, pair):
-        left, self.leftEncoded = self.checkForUnencodedGname(self.font, pair[0])
-        right, self.rightEncoded = self.checkForUnencodedGname(self.font, pair[1])
-        return left + right + left
+        if self.w.mirroredPair.get() == True:
+            left, self.leftEncoded = self.checkForUnencodedGname(self.font, pair[0])
+            right, self.rightEncoded = self.checkForUnencodedGname(self.font, pair[1])
+            return left + right + left
+        else:
+            return ""
 
 
     def wordsForMMPair(self, ):


### PR DESCRIPTION
I’m finding this extension very helpful – thank you so much for releasing it!

As I have been using it, however, one thing stood out to me strongly: there are a lot of kerns which I want to be symmetrical, and in general, I want mirrored kerns to be visually equal. 

So, I’ve added this in as an option. It now looks like this:

![screenshot of modified MM2SpaceCenter in use](https://user-images.githubusercontent.com/45946693/85212581-36ed4200-b322-11ea-99c2-a0a5b81295db.png)

What do you think about this update? I have a couple of other ideas of things that might be handy to add, so please let me know if you think this is a decent way to go about it, or how you’re feeling. Cheers!