### PR TITLE
handle suffixes in kern pair names

### DIFF
--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -121,7 +121,7 @@ class MM2SpaceCenter:
         yPos += lineHeight * 1.2
         
         self.w.handleSuffix = CheckBox((leftMargin, yPos, checkBoxSize, checkBoxSize), "", sizeStyle="small", callback=self.sortedCallback)
-        self.w.handleSuffixLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Strip glyph name suffixes for SC", sizeStyle="small")
+        self.w.handleSuffixLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Handle suffixed glyph names", sizeStyle="small")
         
 
         self.sorted = self.w.listOutput.get()

--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -53,13 +53,10 @@ class MM2SpaceCenter:
         self.maxLength = 15
         
         self.activateModule()
-        self.w = Window((250, 155), "MM2SpaceCenter")
+        self.w = Window((250, 180), "MM2SpaceCenter")
         
         self.w.myTextBox = TextBox((leftMargin, yPos, -10, 17), self.messageText, sizeStyle="regular") 
 
-
-
-        
         yPos += (lineHeight * 1.2) 
 
         
@@ -121,9 +118,13 @@ class MM2SpaceCenter:
         self.w.mirroredPair = CheckBox((leftMargin, yPos, checkBoxSize, checkBoxSize), "", sizeStyle="small", callback=self.sortedCallback)
         self.w.mirroredPairLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Show mirrored pair (LRL)", sizeStyle="small")
         
+        yPos += lineHeight * 1.2
+        
+        self.w.handleSuffix = CheckBox((leftMargin, yPos, checkBoxSize, checkBoxSize), "", sizeStyle="small", callback=self.sortedCallback)
+        self.w.handleSuffixLabel = TextBox((checkBoxSize+5, yPos+2, -leftMargin, checkBoxSize), "Strip glyph name suffixes for SC", sizeStyle="small")
+        
+
         self.sorted = self.w.listOutput.get()
-
-
         
         self.w.bind("close", self.deactivateModule)
         self.w.open()
@@ -452,6 +453,34 @@ class MM2SpaceCenter:
         else:
             return ""
 
+    # chop suffixes off glyphnames to find context strings, but leave them for Space Center
+    def suffixHandle(self, pair):
+
+        currentSC = CurrentSpaceCenter()
+
+        # get first part of glyph name, then return this name below
+        if "." in pair[0]:
+            side1base = pair[0].split(".",1)[0]
+            currentSC.setSuffix("." + pair[0].split(".",1)[1])
+        else:
+            side1base = pair[0] 
+
+        if "." in pair[1]:
+            side2base = pair[1].split(".",1)[0]
+            currentSC.setSuffix("." + pair[1].split(".",1)[1])
+        else:
+            side2base = pair[1]
+
+        # if neither side has a suffix, clear suffixes applied in space center
+        if "." not in pair[0] and "." not in pair[1]:
+            currentSC.setSuffix(None)
+
+        left, self.leftEncoded = self.checkForUnencodedGname(self.font, side1base)
+        right, self.rightEncoded = self.checkForUnencodedGname(self.font, side2base)
+
+        return left + right
+
+
 
     def wordsForMMPair(self, ):
         
@@ -486,7 +515,13 @@ class MM2SpaceCenter:
         pairstring = self.getPairstring(self.pair)
 
         #convert MM tuple into search pair to check uc, lc, mixed case. Maybe need a different var name here? 
-        pair2char = ''.join(self.pair2char(self.pair))
+        # strip suffixes if option is selected
+        if self.w.handleSuffix.get() == True:
+            pair = self.suffixHandle(self.pair)
+            pair2char = ''.join(self.pair2char(pair))
+        else:
+            pair2char = ''.join(self.pair2char(self.pair))
+
         
         
         


### PR DESCRIPTION
A common problem: I am kerning suffixed alternates, and I still want to see them in context strings in the space center. However, the current version of MM2SpaceCenter (which I use all the time) doesn’t handle these, but instead shows `no words for pair`. For instance, I am currently making alternate punctuation, and I see this a lot:

<img width="1541" alt="image" src="https://user-images.githubusercontent.com/45946693/131039238-d235ee59-d332-49e3-8817-03cfa6966b23.png">

So, this PR adds an option to "Handle glyph name suffixes." When active, this simply looks for suffixes, and strips them to once again find contextual strings.

<img width="1539" alt="image" src="https://user-images.githubusercontent.com/45946693/131039289-390595c6-bff0-4d72-82cc-3334e2706c6d.png">

## How it works

This PR handles suffixes by:
- Getting a string match by taking the glyph name, then stripping off everything after the first `.`
- Taking the string after `.`, and using [mojo.UI.setSuffix()](https://robofont.com/documentation/reference/api/mojo/mojo-ui/?highlight=mojo-events#mojo.UI.setSuffix) to set that as the suffix in the current Space Center

Limitation: if both sides of the kern pair have a suffix, the right side (side 2) always wins – because the Space Center can only show one suffix at a time. I could potentially change this around so that the last-input suffixed glyph could always "win," or maybe there is another solution entirely (hopefully short of making a custom Space Center?).
- Hmm, one thought here is that if there are suffixes in the kern pair, the extension could edit the context string to use the glyph names, along with their suffixes. This would allow kerns between two suffixed glyphs. This could potentially be a relative-simply `.replace` operation? I’ll look into it.

## To do

- [ ] Make "Show open+close context {n}" work for suffixes
- [ ] Experiment: make this work for suffixes on both sides

## Questions

- Is there ever a time when users _wouldn’t_ want to handle glyph name suffixes? It’s possible that this should just be part of the normal functionality, rather than an option. But, I’m still using it to see whether there are any bugs with it.
- If this should be an option, is the label obvious enough? How might it be improved?

## Other ideas (probably for another PR)

- Also attempted but failed (for now): having an option to show a comparison mirrored pair. E.g. when I am looking at `A/quotesingle.brut A`, I would also like to see `A/quotesingle A`. 
- A semi-related issue I have: I sometimes want to see `quoteright` in context, but the context strings only match `quotesingle`. Probably, a similar solution could be applied here. 
