### PR TITLE
Dedupe mirrored pair in case of [punctuation UC] pair

### DIFF
--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -835,11 +835,8 @@ class MM2SpaceCenter:
 
                     spacingString = spacingString.replace("  ", " ") ## extra space gets added, later maybe it's best to change self.ucString function??
                     spacingString = spacingString.replace("  ", " ") ## do again to catch double spaces 
-                                
-                    if self.w.mirroredPair.get() == True: #if "start with mirrored pair" is checked, add this to text
-                        text = self.pairMirrored(self.pair) + spacingString + previousText
-                    else:
-                        text = spacingString + previousText
+
+                    text = spacingString + previousText
             
                 if self.w.mirroredPair.get() == True: #if "start with mirrored pair" is checked, add this to text
                     text = self.pairMirrored(self.pair) + text 

--- a/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
+++ b/MM2SpaceCenter.roboFontExt/lib/MM2SpaceCenter.py
@@ -353,8 +353,6 @@ class MM2SpaceCenter:
         escapeList = ['slash', 'backslash']
         
         if (not font[gname].unicodes) or (gname in escapeList):
-            #scString = '/'+gname+' '
-            
             scString = self.spaceCenterStringForUnencoded(gname)
             
         else: 
@@ -373,8 +371,8 @@ class MM2SpaceCenter:
         return pairstring
 
 
-    #convert char gnames to chars to find words in dict
     def pair2char(self, pair):
+        """Convert char gnames to chars to find words in dict."""
         
         self.debug = False
         
@@ -841,7 +839,7 @@ class MM2SpaceCenter:
                     if self.w.mirroredPair.get() == True: #if "start with mirrored pair" is checked, add this to text
                         text = self.pairMirrored(self.pair) + spacingString + previousText
                     else:
-                        text = spacingString + previousText                
+                        text = spacingString + previousText
             
                 if self.w.mirroredPair.get() == True: #if "start with mirrored pair" is checked, add this to text
                     text = self.pairMirrored(self.pair) + text 
@@ -926,19 +924,13 @@ class MM2SpaceCenter:
                 truncatedPairstring = pairstring[0:29]
                 self.messageText = '😎'+ truncatedPairstring+'…'
 
- 
             self.w.statusBar.set(self.messageText)
-            
-
 
 
 def run():
     if not len(AllFonts()) > 0:
         print ('you must have a font open')
         return
-
-
-    
 
     try:
         p = metricsMachine.GetCurrentPair()


### PR DESCRIPTION
https://github.com/cjdunn/MM2SpaceCenter/pull/22 introduced an issue that displayed doubled mirrored pairs, for pairs containing punctuation and uppercase, e.g. `bracketleft T`, or uppercase and figure, e.g. `R 6`.

There was simply a duplicate check and addition of the mirroredPair preference at lines 841–844. This fixes that.

I thought I might have to refactor it more extensively to fix the problem, and while that could potentially still be useful, I don’t have the necessary bandwidth right now. I’m just excited to have a well-working suffix handler!

This effectively closes issue #26, but it does still leave an edge case problem for pair `slash O.RECT`. I will make that a separate issue, though, as it is a much smaller, mostly separate problem.